### PR TITLE
Setup certification path to use secure RPC connection

### DIFF
--- a/coindesk/auth_backends.py
+++ b/coindesk/auth_backends.py
@@ -9,7 +9,8 @@ import grpc
 class SignatureBackend(object):
 
     def authenticate(self, request, signature, csrf_token, username=None):
-        channel = grpc.insecure_channel(settings.LND_RPCHOST)
+        creds = grpc.ssl_channel_credentials(open(settings.CERT_PATH).read())
+        channel = grpc.secure_channel(settings.LND_RPCHOST, creds)
         stub = lnrpc.LightningStub(channel)
 
         verifymessage_resp = stub.VerifyMessage(ln.VerifyMessageRequest(msg=csrf_token, signature=signature))

--- a/coindesk/models.py
+++ b/coindesk/models.py
@@ -76,7 +76,8 @@ class Payment(models.Model):
         Generates a new invoice
         """
         assert self.status == 'pending_invoice', "Already generated invoice"
-        channel = grpc.insecure_channel(settings.LND_RPCHOST)
+        creds = grpc.ssl_channel_credentials(open(settings.CERT_PATH).read())
+        channel = grpc.secure_channel(settings.LND_RPCHOST, creds)
         stub = lnrpc.LightningStub(channel)
 
         add_invoice_resp = stub.AddInvoice(ln.Invoice(value=settings.MIN_VIEW_AMOUNT, memo="User '{}' | ArticleId {}".format(user.username, article.id)))
@@ -93,7 +94,8 @@ class Payment(models.Model):
         if self.status == 'pending_invoice':
             return False
 
-        channel = grpc.insecure_channel(settings.LND_RPCHOST)
+        creds = grpc.ssl_channel_credentials(open(settings.CERT_PATH).read())
+        channel = grpc.secure_channel(settings.LND_RPCHOST, creds)
         stub = lnrpc.LightningStub(channel)
 
         r_hash_base64 = self.r_hash.encode('utf-8')

--- a/coindesk/settings.py
+++ b/coindesk/settings.py
@@ -25,7 +25,7 @@ CERT_PATH = None
 if platform.system() == "Darwin":
     CERT_PATH = os.path.join(os.getenv('HOME'), 'Library/Application Support/Lnd/tls.cert')
 elif platform.system() == "Linux":
-    CERT_PATH = os.path.join(os.getenv('HOME'), 'Lnd/tls.cert')
+    CERT_PATH = os.path.join(os.getenv('HOME'), '.lnd/tls.cert')
 elif platform.system() == "Windows":
     CERT_PATH = os.path.join(os.getenv('APPDATA'), 'Local', 'Lnd', 'tls.cert')
 

--- a/coindesk/settings.py
+++ b/coindesk/settings.py
@@ -9,6 +9,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.10/ref/settings/
 """
 
+import platform
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -18,6 +19,15 @@ PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 LND_RPCHOST = "localhost:10002"
 MIN_VIEW_AMOUNT = 1000
 MIN_UPVOTE_AMOUNT = 1000
+
+# Point to the TLS certification file to initiate secure connections
+CERT_PATH = None
+if platform.system() == "Darwin":
+    CERT_PATH = os.path.join(os.getenv('HOME'), 'Library/Application Support/Lnd/tls.cert')
+elif platform.system() == "Linux":
+    CERT_PATH = os.path.join(os.getenv('HOME'), 'Lnd/tls.cert')
+elif platform.system() == "Windows":
+    CERT_PATH = os.path.join(os.getenv('APPDATA'), 'Local', 'Lnd', 'tls.cert')
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/


### PR DESCRIPTION
Setting up the path to the certification file in settings.py then using it to open secure RPC connections.